### PR TITLE
[base] Switch base to fedora-42

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ env:
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"  # Put your own image here for a fancy profile on https://artifacthub.io/!
   IMAGE_NAME: "bazzite-kdeland-razer"  # output image name, usually same as repo name
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"  # do not edit
-  BUILD_FROM_IMAGE: "ghcr.io/ublue-os/bazzite-nvidia-open:stable"
+  BUILD_FROM_IMAGE: "ghcr.io/ublue-os/bazzite-nvidia-open:stable-42"
   BUILD_SHELL: 1
   BUILD_HYPRLAND: 1
   BUILD_LAPTOP: 1

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ujust update
 
 In order to control what packages are installed you can modify the following variables:
 
- - `BUILD_FROM_IMAGE=<base_image>` the base image, default: `ghcr.io/ublue-os/bazzite-nvidia-open:stable`
+ - `BUILD_FROM_IMAGE=<base_image>` the base image, default: `ghcr.io/ublue-os/bazzite-nvidia-open:stable-42`
  - `BUILD_SHELL=<0|1>` add various commandline utilities, default=1
  - `BUILD_HYPRLAND=<0|1>` add [hyprland](https://hypr.land/) and some other utils to get my preferred configuration running, default=1
  - `BUILD_LAPTOP=<0|1>` add various features which only makes sense on laptops, default=1

--- a/build-local.sh
+++ b/build-local.sh
@@ -6,7 +6,7 @@ TIMESTAMP=`date +%Y%m%d%H%M`
 IMAGE_TAG_PREFIX=$USER/bazzite-kdeland-local
 
 # BUILD ARGUMENTS:
-BUILD_FROM_IMAGE=ghcr.io/ublue-os/bazzite-nvidia-open:stable
+BUILD_FROM_IMAGE=ghcr.io/ublue-os/bazzite-nvidia-open:stable-42
 BUILD_SHELL=1
 BUILD_HYPRLAND=1
 BUILD_LAPTOP=1


### PR DESCRIPTION
Due to issues with [hyprland and Fedora 43](https://github.com/hyprwm/Hyprland/discussions/12668), we're temporarily switching the base image to Fedora 42 builds of bazzite.