### PR TITLE
[base] Set base build image to default to a mirror of `bazzite-stable-42`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ env:
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"  # Put your own image here for a fancy profile on https://artifacthub.io/!
   IMAGE_NAME: "bazzite-kdeland-razer"  # output image name, usually same as repo name
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"  # do not edit
-  BUILD_FROM_IMAGE: "ghcr.io/ublue-os/bazzite-nvidia-open:stable"
+  BUILD_FROM_IMAGE: "ghcr.io/ublue-os/bazzite-nvidia-open:stable-42"
   BUILD_SHELL: 1
   BUILD_HYPRLAND: 1
   BUILD_LAPTOP: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ env:
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"  # Put your own image here for a fancy profile on https://artifacthub.io/!
   IMAGE_NAME: "bazzite-kdeland-razer"  # output image name, usually same as repo name
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"  # do not edit
-  BUILD_FROM_IMAGE: "ghcr.io/ublue-os/bazzite-nvidia-open:stable-42"
+  BUILD_FROM_IMAGE: "ghcr.io/nickfraser/bazzite-nvidia-open:stable-42"
   BUILD_SHELL: 1
   BUILD_HYPRLAND: 1
   BUILD_LAPTOP: 1

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # BUILD_FROM_IMAGE definition MUST be the first (uncommented) line: https://stackoverflow.com/a/78364729
-ARG BUILD_FROM_IMAGE=ghcr.io/ublue-os/bazzite:stable
+ARG BUILD_FROM_IMAGE=ghcr.io/nickfraser/bazzite-nvidia-open:stable-42
 # Allow build scripts to be referenced without being copied into the final image
 FROM scratch AS ctx
 COPY build_files /

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ujust update
 
 In order to control what packages are installed you can modify the following variables:
 
- - `BUILD_FROM_IMAGE=<base_image>` the base image, default: `ghcr.io/ublue-os/bazzite-nvidia-open:stable-42`
+ - `BUILD_FROM_IMAGE=<base_image>` the base image, default: `ghcr.io/nickfraser/bazzite-nvidia-open:stable-42`
  - `BUILD_SHELL=<0|1>` add various commandline utilities, default=1
  - `BUILD_HYPRLAND=<0|1>` add [hyprland](https://hypr.land/) and some other utils to get my preferred configuration running, default=1
  - `BUILD_LAPTOP=<0|1>` add various features which only makes sense on laptops, default=1
@@ -48,6 +48,7 @@ In order to control what packages are installed you can modify the following var
 ## Build Locally
 
 In order to debug various issues, `build-local.sh` is setup to build the image with everything enabled.
+It now defaults to `ghcr.io/nickfraser/bazzite-nvidia-open:stable-42` as the base image.
 
 ## build.sh
 
@@ -56,7 +57,7 @@ It is the entry-point for installing all other applications.
 
 ## build.yml
 
-The [build.yml](./.github/workflows/build.yml) is configured to build the image with the [defaults specified](#environment-variables) and publishes it to the Github Container Registry (GHCR).
+The [build.yml](./.github/workflows/build.yml) is configured to build the image with the [defaults specified](#environment-variables), including the `ghcr.io/nickfraser/bazzite-nvidia-open:stable-42` base image, and publishes it to the Github Container Registry (GHCR).
 
 ## Post-Installation Steps
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ujust update
 
 In order to control what packages are installed you can modify the following variables:
 
- - `BUILD_FROM_IMAGE=<base_image>` the base image, default: `ghcr.io/ublue-os/bazzite-nvidia-open:stable`
+ - `BUILD_FROM_IMAGE=<base_image>` the base image, default: `ghcr.io/ublue-os/bazzite-nvidia-open:stable-42`
  - `BUILD_SHELL=<0|1>` add various commandline utilities, default=1
  - `BUILD_HYPRLAND=<0|1>` add [hyprland](https://hypr.land/) and some other utils to get my preferred configuration running, default=1
  - `BUILD_LAPTOP=<0|1>` add various features which only makes sense on laptops, default=1

--- a/build-local.sh
+++ b/build-local.sh
@@ -6,7 +6,7 @@ TIMESTAMP=`date +%Y%m%d%H%M`
 IMAGE_TAG_PREFIX=$USER/bazzite-kdeland-local
 
 # BUILD ARGUMENTS:
-BUILD_FROM_IMAGE=ghcr.io/ublue-os/bazzite-nvidia-open:stable
+BUILD_FROM_IMAGE=ghcr.io/ublue-os/bazzite-nvidia-open:stable-42
 BUILD_SHELL=1
 BUILD_HYPRLAND=1
 BUILD_LAPTOP=1

--- a/build-local.sh
+++ b/build-local.sh
@@ -6,7 +6,7 @@ TIMESTAMP=`date +%Y%m%d%H%M`
 IMAGE_TAG_PREFIX=$USER/bazzite-kdeland-local
 
 # BUILD ARGUMENTS:
-BUILD_FROM_IMAGE=ghcr.io/ublue-os/bazzite-nvidia-open:stable-42
+BUILD_FROM_IMAGE=ghcr.io/nickfraser/bazzite-nvidia-open:stable-42
 BUILD_SHELL=1
 BUILD_HYPRLAND=1
 BUILD_LAPTOP=1


### PR DESCRIPTION
Fix failed builds due to missing upstream image.